### PR TITLE
🐛 セーブロード後の自動ダイス停止問題を修正

### DIFF
--- a/assets/js/systems/dice-system.js
+++ b/assets/js/systems/dice-system.js
@@ -100,9 +100,9 @@ export class DiceSystem {
     // 自動ダイスの初期化（ゲーム開始時）
     initializeAutoDiceTimers(currentTime) {
         this.gameState.autoDice.forEach(dice => {
-            if (dice.lastRoll === 0) {
-                dice.lastRoll = currentTime;
-            }
+            // セーブデータ読み込み時に古いperformance.now()タイムスタンプが残っているため
+            // すべてのダイスのタイマーを現在時刻でリセット
+            dice.lastRoll = currentTime;
         });
     }
 


### PR DESCRIPTION
セーブデータ読み込み時に古いperformance.now()タイムスタンプが残ることで
自動ダイスが動作しなくなる問題を解決。initializeAutoDiceTimers()で
すべての自動ダイスのタイマーを現在時刻でリセットするよう修正。

🤖 Generated with [Claude Code](https://claude.ai/code)