### PR TITLE
✨ 自動ダイスアップグレードシステムを統合レベル制に改修

### DIFF
--- a/src/core/game-loop.ts
+++ b/src/core/game-loop.ts
@@ -258,9 +258,9 @@ export class GameLoop {
         const autoDiceInfo = this.gameState.autoDice.map((dice, index) => ({
             index,
             faces: dice.faces,
-            unlocked: dice.unlocked,
-            count: dice.count,
-            speedLevel: dice.speedLevel,
+            unlocked: dice.level > 0,
+            count: dice.count || 1,
+            speedLevel: dice.speedLevel || 0,
             lastRoll: dice.lastRoll,
             interval: this.systems.dice.getAutoDiceInterval(index)
         }));

--- a/src/core/game-loop.ts
+++ b/src/core/game-loop.ts
@@ -209,7 +209,7 @@ export class GameLoop {
                 position: this.gameState.position,
                 level: this.gameState.level,
                 credits: this.gameState.credits,
-                autoDiceCount: this.gameState.autoDice.filter(d => d.unlocked).length
+                autoDiceCount: this.gameState.autoDice.filter(d => d.level > 0).length
             }
         };
     }
@@ -255,15 +255,18 @@ export class GameLoop {
     // デバッグ: ゲーム状態の詳細情報取得
     getDetailedDebugInfo(): DetailedDebugInfo {
         const baseInfo = this.getDebugInfo();
-        const autoDiceInfo = this.gameState.autoDice.map((dice, index) => ({
-            index,
-            faces: dice.faces,
-            unlocked: dice.level > 0,
-            count: dice.count || 1,
-            speedLevel: dice.speedLevel || 0,
-            lastRoll: dice.lastRoll,
-            interval: this.systems.dice.getAutoDiceInterval(index)
-        }));
+        const autoDiceInfo = this.gameState.autoDice.map((dice, index) => {
+            const diceInfo = this.systems.dice.getAutoDiceInfo(index);
+            return {
+                index,
+                faces: dice.faces,
+                unlocked: dice.level > 0,
+                count: diceInfo?.count || 1,
+                speedLevel: dice.level,
+                lastRoll: dice.lastRoll,
+                interval: this.systems.dice.getAutoDiceInterval(index)
+            };
+        });
 
         return {
             ...baseInfo,

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -299,7 +299,7 @@ export class SugorokuGame {
             isRunning: debugInfo.gameLoop?.isRunning || false,
             totalCredits: this.gameState?.credits || 0,
             currentLevel: this.gameState?.level || 1,
-            autoDiceCount: this.gameState?.autoDice?.filter(d => d.unlocked).length || 0,
+            autoDiceCount: this.gameState?.autoDice?.filter(d => d.level > 0).length || 0,
             totalStats: this.gameState?.stats || {}
         };
     }

--- a/src/data/game-state.ts
+++ b/src/data/game-state.ts
@@ -32,15 +32,19 @@ export function createDefaultGameState(): GameState {
             upgradeLevel: 0         // アップグレードレベル
         },
         
-        // 自動ダイス（7種類独立）
+        // 自動ダイス（7種類独立）- 新しいレベルシステム
         autoDice: DICE_CONFIGS.map(config => ({
             faces: config.faces,
+            level: 0,               // 0=未解禁、1以上=解禁済み
+            ascensionLevel: 0,      // アセンションレベル
+            baseInterval: config.baseInterval,
+            lastRoll: 0,
+            
+            // 後方互換性のための旧プロパティ（マイグレーション用）
             count: 1,
             unlocked: false,
             speedLevel: 0,
-            countLevel: 0,
-            baseInterval: config.baseInterval,
-            lastRoll: 0
+            countLevel: 0
         })),
         
         // ゲーム設定
@@ -97,6 +101,50 @@ export function mergeGameState(defaultState: GameState, savedState: Partial<Game
             }
         }
     });
+    
+    // 自動ダイスの旧システムから新システムへのマイグレーション
+    if (savedState.autoDice && Array.isArray(savedState.autoDice)) {
+        merged.autoDice = savedState.autoDice.map((savedDice, index) => {
+            const defaultDice = defaultState.autoDice[index];
+            if (!defaultDice || !savedDice) return defaultDice;
+            
+            // 旧システムのプロパティが存在する場合、新システムに変換
+            if (savedDice.unlocked !== undefined || savedDice.speedLevel !== undefined || savedDice.countLevel !== undefined) {
+                console.log(`自動ダイス${index}を旧システムから新システムに変換中...`);
+                
+                const newDice = { ...defaultDice };
+                
+                // 旧システムから新システムへの変換ロジック
+                if (savedDice.unlocked) {
+                    // 解禁済みの場合、旧speedLevelとcountLevelからlevelを計算
+                    const oldSpeedLevel = savedDice.speedLevel || 0;
+                    const oldCountLevel = savedDice.countLevel || 0;
+                    newDice.level = Math.max(1, Math.max(oldSpeedLevel, oldCountLevel) + 1);
+                    newDice.ascensionLevel = 0; // 初期アセンションレベル
+                } else {
+                    // 未解禁の場合
+                    newDice.level = 0;
+                    newDice.ascensionLevel = 0;
+                }
+                
+                // その他のプロパティを引き継ぎ
+                newDice.faces = savedDice.faces || defaultDice.faces;
+                newDice.baseInterval = savedDice.baseInterval || defaultDice.baseInterval;
+                newDice.lastRoll = savedDice.lastRoll || 0;
+                
+                // 後方互換性のため旧プロパティも保持
+                newDice.count = savedDice.count || 1;
+                newDice.unlocked = savedDice.unlocked || false;
+                newDice.speedLevel = savedDice.speedLevel || 0;
+                newDice.countLevel = savedDice.countLevel || 0;
+                
+                return newDice;
+            } else {
+                // 新システムのプロパティが既に存在する場合、そのまま利用
+                return { ...defaultDice, ...savedDice };
+            }
+        }).filter(Boolean) as any[];
+    }
     
     return merged;
 }

--- a/src/systems/dice-system.ts
+++ b/src/systems/dice-system.ts
@@ -31,10 +31,6 @@ interface AutoDiceInfo {
     rollsPerMinute: number;
     lastRoll: number;
     canAscend: boolean;
-    
-    // 後方互換性のため
-    speedLevel?: number;
-    countLevel?: number;
 }
 
 interface ManualDiceInfo {
@@ -228,11 +224,7 @@ export class DiceSystem {
             interval: interval,
             rollsPerMinute: rollsPerMinute,
             lastRoll: dice.lastRoll,
-            canAscend: dice.level >= maxLevel,
-            
-            // 後方互換性
-            speedLevel: dice.speedLevel || 0,
-            countLevel: dice.countLevel || 0
+            canAscend: dice.level >= maxLevel
         };
     }
 

--- a/src/systems/upgrade-system.ts
+++ b/src/systems/upgrade-system.ts
@@ -29,16 +29,6 @@ interface AutoDiceUpgradeInfo {
     canUnlock: boolean;
     canLevelUp: boolean;
     canAscend: boolean;
-    
-    // 後方互換性のため
-    count?: number;
-    speedLevel?: number;
-    countLevel?: number;
-    unlockCost?: number;
-    speedUpgradeCost?: number;
-    countUpgradeCost?: number;
-    canUpgradeSpeed?: boolean;
-    canUpgradeCount?: boolean;
 }
 
 interface AllUpgradeInfo {
@@ -183,18 +173,6 @@ export class UpgradeSystem {
         );
     }
 
-    // 旧システム互換用のコスト計算（後方互換性のため残す）
-    getAutoDiceUnlockCost(diceIndex: number): number {
-        return this.getAutoDiceLevelUpCost(diceIndex);
-    }
-
-    getAutoDiceSpeedUpgradeCost(diceIndex: number): number {
-        return this.getAutoDiceLevelUpCost(diceIndex);
-    }
-
-    getAutoDiceCountUpgradeCost(diceIndex: number): number {
-        return this.getAutoDiceLevelUpCost(diceIndex);
-    }
 
     // アップグレード可能性チェック
     canUpgradeManualDice(): boolean {
@@ -234,14 +212,6 @@ export class UpgradeSystem {
         return dice.level >= maxLevel && this.gameState.credits >= this.getAutoDiceAscensionCost(diceIndex);
     }
 
-    // 旧システム互換用（後方互換性のため残す）
-    canUpgradeAutoDiceSpeed(diceIndex: number): boolean {
-        return this.canLevelUpAutoDice(diceIndex);
-    }
-
-    canUpgradeAutoDiceCount(diceIndex: number): boolean {
-        return this.canLevelUpAutoDice(diceIndex);
-    }
 
     // 全アップグレード情報の取得
     getAllUpgradeInfo(): AllUpgradeInfo {
@@ -270,17 +240,7 @@ export class UpgradeSystem {
                 ascensionCost: this.getAutoDiceAscensionCost(index),
                 canUnlock: this.canUnlockAutoDice(index),
                 canLevelUp: this.canLevelUpAutoDice(index),
-                canAscend: this.canAscendAutoDice(index),
-                
-                // 後方互換性
-                count: dice.count || 1,
-                speedLevel: dice.speedLevel || 0,
-                countLevel: dice.countLevel || 0,
-                unlockCost: this.getAutoDiceUnlockCost(index),
-                speedUpgradeCost: this.getAutoDiceSpeedUpgradeCost(index),
-                countUpgradeCost: this.getAutoDiceCountUpgradeCost(index),
-                canUpgradeSpeed: this.canUpgradeAutoDiceSpeed(index),
-                canUpgradeCount: this.canUpgradeAutoDiceCount(index)
+                canAscend: this.canAscendAutoDice(index)
             };
         });
 
@@ -297,11 +257,6 @@ export class UpgradeSystem {
         
         this.gameState.autoDice.forEach(dice => {
             total += dice.level + dice.ascensionLevel; // レベル + アセンション数
-            
-            // 後方互換性のため旧システムのカウントも含める
-            if (dice.speedLevel) total += dice.speedLevel;
-            if (dice.countLevel) total += dice.countLevel;
-            if (dice.unlocked) total += 1; // 旧システムの解禁もカウント
         });
         
         return total;

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -89,6 +89,19 @@ export interface BurdenConfig {
     LEVEL_3_START: number;
 }
 
+// 自動ダイスレベルシステム設定の型定義
+export interface AutoDiceLevelConfig {
+    MAX_LEVEL_BASE: number;
+    ASCENSION_LEVEL_INCREMENT: number;
+    ASCENSION_COST_MULTIPLIER: number;
+    SPEED_MULTIPLIER_MAX: number;
+    DICE_COUNT_BASE: number;
+    DICE_COUNT_MULTIPLIER: number;
+    LEVEL_COST_BASE: number;
+    LEVEL_COST_MULTIPLIER: number;
+    ASCENSION_COST_BASE_MULTIPLIER: number;
+}
+
 // ストレージキー設定の型定義
 export interface StorageKeys {
     GAME_STATE: string;

--- a/src/types/game-state.ts
+++ b/src/types/game-state.ts
@@ -21,12 +21,16 @@ export interface ManualDice {
 
 export interface AutoDice {
     faces: number;         // ダイスの面数
-    count: number;         // ダイスの個数
-    unlocked: boolean;     // 解禁状態
-    speedLevel: number;    // 速度レベル
-    countLevel: number;    // 個数レベル
+    level: number;         // ダイスレベル（0=未解禁、1以上=解禁済み）
+    ascensionLevel: number; // アセンションレベル
     baseInterval: number;  // 基本実行間隔（ティック数）
     lastRoll: number;      // 最後にロールしたTick
+    
+    // 後方互換性のための旧システムプロパティ（マイグレーション用）
+    unlocked?: boolean;     // 解禁状態（旧）
+    speedLevel?: number;    // 速度レベル（旧）
+    countLevel?: number;    // 個数レベル（旧）
+    count?: number;         // ダイスの個数（旧）
 }
 
 export interface GameSettings {

--- a/src/types/game-state.ts
+++ b/src/types/game-state.ts
@@ -25,12 +25,6 @@ export interface AutoDice {
     ascensionLevel: number; // アセンションレベル
     baseInterval: number;  // 基本実行間隔（ティック数）
     lastRoll: number;      // 最後にロールしたTick
-    
-    // 後方互換性のための旧システムプロパティ（マイグレーション用）
-    unlocked?: boolean;     // 解禁状態（旧）
-    speedLevel?: number;    // 速度レベル（旧）
-    countLevel?: number;    // 個数レベル（旧）
-    count?: number;         // ダイスの個数（旧）
 }
 
 export interface GameSettings {

--- a/src/ui/ui-manager.ts
+++ b/src/ui/ui-manager.ts
@@ -103,30 +103,6 @@ interface SquareEffect {
     moveResult?: MoveResult;
 }
 
-// アップグレード情報の型定義
-interface UpgradeInfo {
-    manual: {
-        cost: number;
-        canAfford: boolean;
-        currentCount: number;
-        currentLevel: number;
-    };
-    auto: Array<{
-        index: number;
-        faces: number;
-        unlocked: boolean;
-        count: number;
-        speedLevel: number;
-        countLevel: number;
-        unlockCost: number;
-        speedUpgradeCost: number;
-        countUpgradeCost: number;
-        canUnlock: boolean;
-        canUpgradeSpeed: boolean;
-        canUpgradeCount: boolean;
-    }>;
-    totalCredits: number;
-}
 
 export class UIManager {
     private gameState: GameState;
@@ -530,7 +506,7 @@ export class UIManager {
     }
 
     // 自動ダイスパネルの作成
-    createAutoDicePanel(diceInfo: UpgradeInfo['auto'][0]): HTMLElement {
+    createAutoDicePanel(diceInfo: any): HTMLElement {
         const config = DICE_CONFIGS[diceInfo.index];
         if (!config) {
             return document.createElement('div');
@@ -547,20 +523,24 @@ export class UIManager {
                 <h6 class="text-muted">${config.emoji} ${diceInfo.faces}面ダイス</h6>
                 <button class="btn btn-outline-warning btn-sm w-100" 
                         data-action="unlock" data-index="${diceInfo.index}">
-                    解禁する
-                    <br><small>コスト: ${formatNumber(diceInfo.unlockCost)}💰</small>
+                    解禁する（レベル1）
+                    <br><small>コスト: ${formatNumber(diceInfo.levelUpCost)}💰</small>
                 </button>
             `;
         } else {
-            // 解禁済み状態 - 進捗ゲージと間隔情報を追加
+            // 解禁済み状態 - レベル・アセンション情報を表示
             const autoDiceInfo = this.systems.dice.getAutoDiceInfo(diceInfo.index);
             const intervalSeconds = autoDiceInfo ? this.ticksToSeconds(autoDiceInfo.interval) : 0;
             const progressInfo = this.calculateAutoDiceProgress(diceInfo.index);
             
+            // アセンション可能かチェック
+            const canAscend = diceInfo.level >= diceInfo.maxLevel;
+            
             panel.innerHTML = `
                 <h6 class="text-success">${config.emoji} ${diceInfo.faces}面ダイス</h6>
                 <div class="mb-2">
-                    <small class="text-muted">個数: ${diceInfo.count} | 速度Lv: ${diceInfo.speedLevel}</small>
+                    <small class="text-muted">レベル: ${diceInfo.level}/${diceInfo.maxLevel} | アセンション: ${diceInfo.ascensionLevel}</small>
+                    <br><small class="text-muted">個数: ${autoDiceInfo?.count || 1}</small>
                     <br><small class="text-info">間隔: ${intervalSeconds.toFixed(1)}秒 | 毎分: ${autoDiceInfo?.rollsPerMinute || 0}回</small>
                 </div>
                 <div class="mb-2">
@@ -574,16 +554,19 @@ export class UIManager {
                     <small class="text-muted">残り: <span data-dice-timer="${diceInfo.index}">${this.ticksToSeconds(progressInfo.timeLeft).toFixed(1)}s</span></small>
                 </div>
                 <div class="d-grid gap-1">
-                    <button class="btn btn-outline-primary btn-sm" 
-                            data-action="speed" data-index="${diceInfo.index}">
-                        速度アップグレード
-                        <br><small>コスト: ${formatNumber(diceInfo.speedUpgradeCost)}💰</small>
-                    </button>
-                    <button class="btn btn-outline-success btn-sm" 
-                            data-action="count" data-index="${diceInfo.index}">
-                        個数アップグレード
-                        <br><small>コスト: ${formatNumber(diceInfo.countUpgradeCost)}💰</small>
-                    </button>
+                    ${canAscend ? `
+                        <button class="btn btn-outline-danger btn-sm" 
+                                data-action="ascend" data-index="${diceInfo.index}">
+                            アセンション
+                            <br><small>コスト: ${formatNumber(diceInfo.ascensionCost)}💰</small>
+                        </button>
+                    ` : `
+                        <button class="btn btn-outline-primary btn-sm" 
+                                data-action="levelup" data-index="${diceInfo.index}">
+                            レベルアップ
+                            <br><small>コスト: ${formatNumber(diceInfo.levelUpCost)}💰</small>
+                        </button>
+                    `}
                 </div>
             `;
         }
@@ -603,13 +586,24 @@ export class UIManager {
                         this.updateUI();
                     }
                     break;
+                case 'levelup':
+                    if (this.systems.upgrade.levelUpAutoDice(index)) {
+                        this.updateUI();
+                    }
+                    break;
+                case 'ascend':
+                    if (this.systems.upgrade.ascendAutoDice(index)) {
+                        this.updateUI();
+                    }
+                    break;
+                // 後方互換性のため旧システムのアクションも残す
                 case 'speed':
-                    if (this.systems.upgrade.upgradeAutoDiceSpeed(index)) {
+                    if (this.systems.upgrade.levelUpAutoDice(index)) {
                         this.updateUI();
                     }
                     break;
                 case 'count':
-                    if (this.systems.upgrade.upgradeAutoDiceCount(index)) {
+                    if (this.systems.upgrade.levelUpAutoDice(index)) {
                         this.updateUI();
                     }
                     break;
@@ -641,15 +635,24 @@ export class UIManager {
                 switch (action) {
                     case 'unlock':
                         canAfford = diceInfo.canUnlock;
-                        cost = diceInfo.unlockCost;
+                        cost = diceInfo.levelUpCost;
                         break;
+                    case 'levelup':
+                        canAfford = diceInfo.canLevelUp;
+                        cost = diceInfo.levelUpCost;
+                        break;
+                    case 'ascend':
+                        canAfford = diceInfo.canAscend;
+                        cost = diceInfo.ascensionCost;
+                        break;
+                    // 後方互換性のため
                     case 'speed':
-                        canAfford = diceInfo.canUpgradeSpeed;
-                        cost = diceInfo.speedUpgradeCost;
+                        canAfford = diceInfo.canLevelUp;
+                        cost = diceInfo.levelUpCost;
                         break;
                     case 'count':
-                        canAfford = diceInfo.canUpgradeCount;
-                        cost = diceInfo.countUpgradeCost;
+                        canAfford = diceInfo.canLevelUp;
+                        cost = diceInfo.levelUpCost;
                         break;
                 }
                 

--- a/src/ui/ui-manager.ts
+++ b/src/ui/ui-manager.ts
@@ -596,17 +596,6 @@ export class UIManager {
                         this.updateUI();
                     }
                     break;
-                // 後方互換性のため旧システムのアクションも残す
-                case 'speed':
-                    if (this.systems.upgrade.levelUpAutoDice(index)) {
-                        this.updateUI();
-                    }
-                    break;
-                case 'count':
-                    if (this.systems.upgrade.levelUpAutoDice(index)) {
-                        this.updateUI();
-                    }
-                    break;
             }
         });
         
@@ -644,15 +633,6 @@ export class UIManager {
                     case 'ascend':
                         canAfford = diceInfo.canAscend;
                         cost = diceInfo.ascensionCost;
-                        break;
-                    // 後方互換性のため
-                    case 'speed':
-                        canAfford = diceInfo.canLevelUp;
-                        cost = diceInfo.levelUpCost;
-                        break;
-                    case 'count':
-                        canAfford = diceInfo.canLevelUp;
-                        cost = diceInfo.levelUpCost;
                         break;
                 }
                 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -12,6 +12,7 @@ import type {
     UIConfig,
     PrestigeConfig,
     BurdenConfig,
+    AutoDiceLevelConfig,
     StorageKeys
 } from '../types/constants.js';
 
@@ -103,6 +104,19 @@ export const BURDEN_CONFIG: BurdenConfig = {
     LEVEL_1_START: 201,        // 負荷レベル1開始
     LEVEL_2_START: 501,        // 負荷レベル2開始
     LEVEL_3_START: 1001        // 負荷レベル3開始
+};
+
+// 自動ダイスレベルシステム設定
+export const AUTO_DICE_LEVEL_CONFIG: AutoDiceLevelConfig = {
+    MAX_LEVEL_BASE: 100,           // 基本最大レベル
+    ASCENSION_LEVEL_INCREMENT: 10, // アセンションごとのレベル上限増加
+    ASCENSION_COST_MULTIPLIER: 10, // アセンション時のコスト倍率
+    SPEED_MULTIPLIER_MAX: 10,      // レベル100時の速度倍率
+    DICE_COUNT_BASE: 1,            // レベル1時のダイス個数
+    DICE_COUNT_MULTIPLIER: 2,      // アセンションごとのダイス個数倍率
+    LEVEL_COST_BASE: 50,           // レベルアップ基本コスト
+    LEVEL_COST_MULTIPLIER: 1.15,   // レベルごとのコスト増加率
+    ASCENSION_COST_BASE_MULTIPLIER: 3 // アセンション後のコスト基本倍率増加
 };
 
 // 統計表示用定数

--- a/src/utils/math-utils.ts
+++ b/src/utils/math-utils.ts
@@ -71,3 +71,47 @@ export function calculatePrestigePointsForLevel(level: number, startLevel: numbe
     const points = basePoints * Math.exp(scalingPower * (level - startLevel));
     return Math.round(points);
 }
+
+// === 新しいレベルシステム用計算関数 ===
+
+// 自動ダイスの最大レベル計算
+export function calculateMaxLevel(ascensionLevel: number, baseMaxLevel: number, increment: number): number {
+    return baseMaxLevel + (ascensionLevel * increment);
+}
+
+// 自動ダイスレベルアップのコスト計算
+export function calculateLevelUpCost(diceIndex: number, currentLevel: number, ascensionLevel: number, 
+                                   baseCost: number, multiplier: number, ascensionCostMultiplier: number): number {
+    // 基本コスト = ダイス種類別の基本コスト * アセンションレベルによる基本コスト倍率
+    const baseForDice = baseCost * Math.pow(ascensionCostMultiplier, ascensionLevel);
+    
+    // ダイス種類別の基本コスト調整（高面数ダイスほど高コスト）
+    const diceMultiplier = Math.pow(2, diceIndex);
+    
+    // レベルによる乗数
+    const levelMultiplier = Math.pow(multiplier, currentLevel);
+    
+    return Math.floor(baseForDice * diceMultiplier * levelMultiplier);
+}
+
+// アセンションコスト計算
+export function calculateAscensionCost(diceIndex: number, currentLevel: number, ascensionLevel: number,
+                                     baseCost: number, multiplier: number, ascensionCostMultiplier: number,
+                                     ascensionPenalty: number): number {
+    const levelUpCost = calculateLevelUpCost(diceIndex, currentLevel, ascensionLevel, baseCost, multiplier, ascensionCostMultiplier);
+    return Math.floor(levelUpCost * ascensionPenalty);
+}
+
+// 自動ダイスの速度計算（レベルベース）
+export function calculateDiceSpeedFromLevel(level: number, baseInterval: number, maxSpeedMultiplier: number): number {
+    if (level === 0) return baseInterval; // 未解禁
+    
+    // レベル1 = 1倍、レベル100 = 10倍の速度でべき乗算増加
+    const speedMultiplier = Math.pow(maxSpeedMultiplier, (level - 1) / 99);
+    return Math.floor(baseInterval / speedMultiplier);
+}
+
+// 自動ダイスの個数計算（アセンションベース）
+export function calculateDiceCountFromAscension(ascensionLevel: number, baseCount: number, multiplier: number): number {
+    return baseCount * Math.pow(multiplier, ascensionLevel);
+}


### PR DESCRIPTION
- 自動ダイス種類ごとに「速度」と「個数」の2つのアップグレードを1つの「レベル」に統合
- レベル0（未解禁）からレベル100（最大）までのレベルアップ制を導入
- レベル100到達後にアセンション機能を追加（レベルリセット、ダイス個数2倍、レベル上限10増加）
- アセンションレベルによるダイス個数の指数的増加（1回目：2個、2回目：4個、3回目：8個...）
- レベルベースの速度計算（レベル1→1倍、レベル100→10倍のべき乗算増加）
- 旧システムから新システムへの自動マイグレーション機能
- UI更新：レベル・アセンション情報の表示、統合ボタン

🤖 Generated with [Claude Code](https://claude.ai/code)