### PR TITLE
⚡️ 負荷システムの調整: 100レベル間隔と新しい減少ルールを実装

### DIFF
--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -78,9 +78,9 @@ export interface PrestigeConfig {
 
 // 負荷システム設定の型定義
 export interface BurdenConfig {
-    LEVEL_1_START: number;
-    LEVEL_2_START: number;
-    LEVEL_3_START: number;
+    LEVEL_INTERVAL: number;           // 負荷レベル上昇の間隔 (100レベルごと)
+    MAX_INDIVIDUAL_REDUCTION: number; // 個別ダイス減少の最大値 (-10)
+    HALVING_INTERVAL: number;         // 総計半減の間隔 (10負荷レベルごと)
 }
 
 // 自動ダイスレベルシステム設定の型定義

--- a/src/ui/ui-manager.ts
+++ b/src/ui/ui-manager.ts
@@ -504,12 +504,22 @@ export class UIManager {
             }
             if (this.elements.burdenEffects) {
                 let effectText = '';
-                if (burdenInfo.diceReduction > 0) {
-                    effectText += `出目-${burdenInfo.diceReduction}`;
+                
+                // 負荷1ごとに総計-1の効果
+                if (burdenInfo.level > 0) {
+                    effectText += `総計-${burdenInfo.level}`;
                 }
+                
+                // 負荷2ごとに個別ダイス-1の効果
+                if (burdenInfo.diceReduction > 0) {
+                    effectText += effectText ? `, 個別-${burdenInfo.diceReduction}` : `個別-${burdenInfo.diceReduction}`;
+                }
+                
+                // 負荷10ごとに総計半減の効果
                 if (burdenInfo.totalHalving) {
                     effectText += effectText ? ', 総計半減' : '総計半減';
                 }
+                
                 this.elements.burdenEffects.textContent = effectText;
             }
         } else {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -118,9 +118,9 @@ export const PRESTIGE_CONFIG: PrestigeConfig = {
 
 // 負荷システム設定
 export const BURDEN_CONFIG: BurdenConfig = {
-    LEVEL_1_START: 201,        // 負荷レベル1開始
-    LEVEL_2_START: 501,        // 負荷レベル2開始
-    LEVEL_3_START: 1001        // 負荷レベル3開始
+    LEVEL_INTERVAL: 100,           // 100レベルごとに負荷レベル+1
+    MAX_INDIVIDUAL_REDUCTION: 10,  // 個別ダイス減少の最大値 (-10)
+    HALVING_INTERVAL: 10           // 10負荷レベルごとに総計半減
 };
 
 // 自動ダイスレベルシステム設定


### PR DESCRIPTION
- レベル101から開始、100レベルごとに負荷レベル+1に変更
- 負荷1ごとに出目総計-1を追加
- 負荷2ごとに個別ダイス出目-1 (最大-10)を実装
- 負荷10ごとに出目総計半減を追加
- UI表示を新ロジックに対応 (総計-X, 個別-Y, 総計半減)

🤖 Generated with [Claude Code](https://claude.ai/code)