### PR TITLE
✨ 自動ダイスまとめ買い機能の実装

### DIFF
--- a/src/systems/upgrade-system.ts
+++ b/src/systems/upgrade-system.ts
@@ -6,7 +6,8 @@ import {
     calculateAscensionCost,
     calculateMaxLevel,
     calculateBulkLevelUpCost,
-    calculateMaxPurchasableCount
+    calculateMaxPurchasableCount,
+    calculateMaxPurchasableCountNoAscension
 } from '../utils/math-utils.js';
 import { DICE_CONFIGS, UPGRADE_MULTIPLIERS, MANUAL_DICE_CONFIG, AUTO_DICE_LEVEL_CONFIG } from '../utils/constants.js';
 import type { GameState, BulkPurchaseAmount, BulkUpgradeInfo } from '../types/game-state.js';
@@ -293,6 +294,16 @@ export class UpgradeSystem {
                 AUTO_DICE_LEVEL_CONFIG.LEVEL_COST_MULTIPLIER,
                 AUTO_DICE_LEVEL_CONFIG.ASCENSION_COST_BASE_MULTIPLIER,
                 AUTO_DICE_LEVEL_CONFIG.ASCENSION_COST_MULTIPLIER
+            );
+        } else if (amount === 'max-no-ascension') {
+            targetCount = calculateMaxPurchasableCountNoAscension(
+                diceIndex,
+                dice.level,
+                dice.ascension,
+                this.gameState.credits,
+                AUTO_DICE_LEVEL_CONFIG.LEVEL_COST_BASE,
+                AUTO_DICE_LEVEL_CONFIG.LEVEL_COST_MULTIPLIER,
+                AUTO_DICE_LEVEL_CONFIG.ASCENSION_COST_BASE_MULTIPLIER
             );
         } else {
             targetCount = amount;

--- a/src/types/game-state.ts
+++ b/src/types/game-state.ts
@@ -87,7 +87,7 @@ export interface UpgradeInfo {
 }
 
 // まとめ買い用の型定義
-export type BulkPurchaseAmount = 1 | 5 | 10 | 'max';
+export type BulkPurchaseAmount = 1 | 5 | 10 | 'max' | 'max-no-ascension';
 
 export interface BulkUpgradeInfo {
     amount: BulkPurchaseAmount;

--- a/src/types/game-state.ts
+++ b/src/types/game-state.ts
@@ -86,6 +86,18 @@ export interface UpgradeInfo {
     canAfford: boolean;
 }
 
+// まとめ買い用の型定義
+export type BulkPurchaseAmount = 1 | 5 | 10 | 'max';
+
+export interface BulkUpgradeInfo {
+    amount: BulkPurchaseAmount;
+    actualCount: number;          // 実際に購入される個数
+    totalCost: number;            // 総コスト
+    canAfford: boolean;           // 購入可能かどうか
+    willReachMaxLevel: boolean;   // 最大レベルに到達するか
+    ascensionsIncluded: number;   // 含まれるアセンション回数
+}
+
 // アニメーション関連の型定義
 export interface AnimationConfig {
     duration: number;

--- a/src/ui/ui-manager.ts
+++ b/src/ui/ui-manager.ts
@@ -809,7 +809,7 @@ export class UIManager {
                     const singleCost = this.systems.upgrade.getAutoDiceLevelUpCost(diceIndex);
                     const costText = this.formatNumberBySetting(singleCost);
                     
-                    button.innerHTML = `Lv.up - ${costText}💰（購入不可）`;
+                    button.innerHTML = `Lv.up - ${costText}💰`;
                     button.disabled = true;
                     
                     // ボタンを購入不可状態に設定

--- a/src/utils/math-utils.ts
+++ b/src/utils/math-utils.ts
@@ -286,3 +286,29 @@ export function calculateMaxPurchasableCount(diceIndex: number, currentLevel: nu
     
     return maxCount;
 }
+
+// アセンション前で停止する最大購入可能個数を計算
+export function calculateMaxPurchasableCountNoAscension(diceIndex: number, currentLevel: number, ascensionLevel: number,
+                                                       availableCredits: number, baseCost: number, multiplier: number,
+                                                       ascensionCostMultiplier: number): number {
+    let maxCount = 0;
+    let totalCost = 0;
+    let tempLevel = currentLevel;
+    
+    const maxLevel = calculateMaxLevel(ascensionLevel, AUTO_DICE_LEVEL_CONFIG.MAX_LEVEL_BASE, AUTO_DICE_LEVEL_CONFIG.ASCENSION_LEVEL_INCREMENT);
+    
+    // 最大レベルに到達するまでの購入可能数を計算
+    while (tempLevel < maxLevel && maxCount < 1000) { // 無限ループ防止
+        const nextCost = calculateLevelUpCost(diceIndex, tempLevel, ascensionLevel, baseCost, multiplier, ascensionCostMultiplier);
+        
+        if (totalCost + nextCost <= availableCredits) {
+            totalCost += nextCost;
+            maxCount++;
+            tempLevel++;
+        } else {
+            break;
+        }
+    }
+    
+    return maxCount;
+}

--- a/src/utils/math-utils.ts
+++ b/src/utils/math-utils.ts
@@ -203,3 +203,86 @@ export function calculateDiceSpeedFromLevel(level: number, baseInterval: number,
 export function calculateDiceCountFromAscension(ascensionLevel: number, baseCount: number, multiplier: number): number {
     return baseCount * Math.pow(multiplier, ascensionLevel);
 }
+
+// === まとめ買い関連の計算関数 ===
+
+// まとめ買い時の総コスト計算（アセンション境界考慮）
+export function calculateBulkLevelUpCost(diceIndex: number, currentLevel: number, ascensionLevel: number,
+                                       targetCount: number, baseCost: number, multiplier: number, 
+                                       ascensionCostMultiplier: number, ascensionPenalty: number): {
+    totalCost: number;
+    actualCount: number;
+    ascensionsIncluded: number;
+} {
+    let totalCost = 0;
+    let actualCount = 0;
+    let ascensionsIncluded = 0;
+    let tempLevel = currentLevel;
+    let tempAscension = ascensionLevel;
+    
+    for (let i = 0; i < targetCount; i++) {
+        const maxLevel = calculateMaxLevel(tempAscension, AUTO_DICE_LEVEL_CONFIG.MAX_LEVEL_BASE, AUTO_DICE_LEVEL_CONFIG.ASCENSION_LEVEL_INCREMENT);
+        
+        if (tempLevel < maxLevel) {
+            // 通常のレベルアップ
+            const levelUpCost = calculateLevelUpCost(diceIndex, tempLevel, tempAscension, baseCost, multiplier, ascensionCostMultiplier);
+            totalCost += levelUpCost;
+            tempLevel++;
+            actualCount++;
+        } else {
+            // アセンションが必要
+            const ascensionCost = calculateAscensionCost(diceIndex, tempLevel, tempAscension, baseCost, multiplier, ascensionCostMultiplier, ascensionPenalty);
+            totalCost += ascensionCost;
+            tempLevel = 1; // アセンション後はレベル1
+            tempAscension++;
+            ascensionsIncluded++;
+            actualCount++; // アセンションもカウントに含める
+        }
+    }
+    
+    return {
+        totalCost,
+        actualCount,
+        ascensionsIncluded
+    };
+}
+
+// 指定したクレジット内で購入可能な最大個数を計算
+export function calculateMaxPurchasableCount(diceIndex: number, currentLevel: number, ascensionLevel: number,
+                                           availableCredits: number, baseCost: number, multiplier: number,
+                                           ascensionCostMultiplier: number, ascensionPenalty: number): number {
+    let maxCount = 0;
+    let totalCost = 0;
+    let tempLevel = currentLevel;
+    let tempAscension = ascensionLevel;
+    
+    // 最大1000回まで試行（無限ループ防止）
+    for (let i = 0; i < 1000; i++) {
+        const maxLevel = calculateMaxLevel(tempAscension, AUTO_DICE_LEVEL_CONFIG.MAX_LEVEL_BASE, AUTO_DICE_LEVEL_CONFIG.ASCENSION_LEVEL_INCREMENT);
+        
+        let nextCost = 0;
+        if (tempLevel < maxLevel) {
+            // 通常のレベルアップコスト
+            nextCost = calculateLevelUpCost(diceIndex, tempLevel, tempAscension, baseCost, multiplier, ascensionCostMultiplier);
+        } else {
+            // アセンションコスト
+            nextCost = calculateAscensionCost(diceIndex, tempLevel, tempAscension, baseCost, multiplier, ascensionCostMultiplier, ascensionPenalty);
+        }
+        
+        if (totalCost + nextCost <= availableCredits) {
+            totalCost += nextCost;
+            maxCount++;
+            
+            if (tempLevel < maxLevel) {
+                tempLevel++;
+            } else {
+                tempLevel = 1;
+                tempAscension++;
+            }
+        } else {
+            break;
+        }
+    }
+    
+    return maxCount;
+}


### PR DESCRIPTION
## Summary
- 自動ダイスアップグレードのまとめ買い機能を実装
- 購入数選択（x1, x5, x10, Max, Max-）の統一化
- アセンション前停止オプション（Max-）の追加
- UI改善とパフォーマンス最適化

## 主な変更点
- **まとめ買い機能**: 1回、5回、10回、Max購入に対応
- **アセンション境界制御**: Max-オプションでアセンション直前で停止
- **UI統一化**: 全ダイス共通の購入数選択インターフェース  
- **コスト計算改善**: アセンション境界を考慮した正確なコスト計算
- **パフォーマンス最適化**: 不要な再生成を防止、部分更新の活用

## Test plan
- [ ] 各購入数（x1, x5, x10）でのまとめ買い動作確認
- [ ] Maxオプションでの最大購入数計算の正確性確認
- [ ] Max-オプションでのアセンション前停止動作確認
- [ ] アセンション境界での適切なコスト計算確認
- [ ] UI応答性とボタン状態の正確な更新確認

🤖 Generated with [Claude Code](https://claude.ai/code)