### PR TITLE
🐛 進むマス効果でレベルアップした時の盤面UI更新不具合を修正

### DIFF
--- a/src/systems/board-system.ts
+++ b/src/systems/board-system.ts
@@ -36,6 +36,8 @@ interface SquareEffect {
     position: number;
     applied: boolean;
     moveResult?: MoveResult;
+    levelChanged?: boolean;  // マス効果による移動でレベル変更が発生したか
+    prestigeEarned?: number; // マス効果による移動で獲得したプレステージポイント
 }
 
 interface PositionInfo {
@@ -385,6 +387,8 @@ export class BoardSystem {
                     // 移動を実行（再帰的な効果は無視）
                     const forwardResult = this.movePlayerDirect(cellData.effect);
                     effect.moveResult = forwardResult;
+                    effect.levelChanged = forwardResult.levelChanged;
+                    effect.prestigeEarned = forwardResult.prestigeEarned;
 
                     // 移動先のマス効果を適用するため、再帰的に呼び出す
                     this.applySquareEffect(forwardResult.newPosition, recurseCount + 1);
@@ -399,6 +403,8 @@ export class BoardSystem {
                     const maxBackwardSteps = Math.min(cellData.effect, this.gameState.position);
                     const backwardResult = this.movePlayerDirect(-maxBackwardSteps);
                     effect.moveResult = backwardResult;
+                    effect.levelChanged = backwardResult.levelChanged;
+                    effect.prestigeEarned = backwardResult.prestigeEarned;
                     
                     // 移動先のマス効果を適用するため、再帰的に呼び出す
                     this.applySquareEffect(backwardResult.newPosition, recurseCount + 1);

--- a/src/ui/ui-manager.ts
+++ b/src/ui/ui-manager.ts
@@ -127,6 +127,8 @@ interface SquareEffect {
     type: string;
     position: number;
     moveResult?: MoveResult;
+    levelChanged?: boolean;  // マス効果による移動でレベル変更が発生したか
+    prestigeEarned?: number; // マス効果による移動で獲得したプレステージポイント
 }
 
 
@@ -325,6 +327,13 @@ export class UIManager {
     animateSquareEffect(effect: SquareEffect): void {
         const cell = this.elements.gameBoard?.querySelector(`[data-position="${effect.position}"]`) as HTMLElement;
         if (!cell) return;
+        
+        // マス効果でレベル変更が発生した場合、盤面UIを更新
+        if (effect.levelChanged) {
+            this.generateGameBoard();
+            // 基本情報も更新
+            this.updateGameInfo();
+        }
         
         switch (effect.type) {
             case 'credit':

--- a/src/ui/ui-manager.ts
+++ b/src/ui/ui-manager.ts
@@ -328,6 +328,7 @@ export class UIManager {
         
         switch (effect.type) {
             case 'credit':
+            case 'credit_bonus':
                 this.animationManager.animateCreditGain(cell);
                 break;
             case 'forward':


### PR DESCRIPTION
## Summary
- 進むマスを踏んで次のレベルに進んだ時に盤面UIが更新されない不具合を修正
- SquareEffect型にレベル変更情報を追加してUI層で検出できるよう改善
- credit_bonusエフェクトのアニメーション処理も追加

## Changes
- **SquareEffect型の拡張**: `levelChanged`と`prestigeEarned`プロパティを追加
- **board-system.ts**: `applySquareEffect`でマス効果による移動のレベル変更情報を記録
- **ui-manager.ts**: `animateSquareEffect`でレベル変更検出時に盤面UIを自動更新
- **ui-manager.ts**: credit_bonusマス効果のアニメーション処理を追加

## Test plan
- [ ] 進むマスを踏んでレベルアップが発生する際に盤面UIが正しく更新されることを確認
- [ ] 戻るマスでは前レベルに戻らず現在レベルの0マス目で停止することを確認
- [ ] credit_bonusマスのアニメーションが正常に動作することを確認
- [ ] 既存の盤面UI更新機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)